### PR TITLE
单元测试时控制器加属性注解报错

### DIFF
--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
-
 declare(strict_types=1);
+
 /**
  * This file is part of Hyperf.
  *
@@ -10,12 +10,21 @@ declare(strict_types=1);
  * @license  https://github.com/hyperf-cloud/hyperf/blob/master/LICENSE
  */
 
+use Hyperf\Contract\ApplicationInterface;
+use Swoole\Runtime;
+
+ini_set('display_errors', 'on');
+ini_set('display_startup_errors', 'on');
+
 error_reporting(E_ALL);
+date_default_timezone_set('Asia/Shanghai');
 
-! defined('BASE_PATH') && define('BASE_PATH', dirname(__DIR__, 1));
+!defined('BASE_PATH') && define('BASE_PATH', dirname(__DIR__, 1));
 
-\Swoole\Runtime::enableCoroutine(true);
+Runtime::enableCoroutine(true);
 
-require BASE_PATH . '/vendor/autoload.php';
+require BASE_PATH.'/vendor/autoload.php';
 
-require BASE_PATH . '/config/container.php';
+$container = require BASE_PATH.'/config/container.php';
+
+$container->get(ApplicationInterface::class);

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -21,8 +21,6 @@ date_default_timezone_set('Asia/Shanghai');
 
 !defined('BASE_PATH') && define('BASE_PATH', dirname(__DIR__, 1));
 
-Runtime::enableCoroutine(true);
-
 require BASE_PATH.'/vendor/autoload.php';
 
 $container = require BASE_PATH.'/config/container.php';

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
-declare(strict_types=1);
 
+declare(strict_types=1);
 /**
  * This file is part of Hyperf.
  *
@@ -10,19 +10,18 @@ declare(strict_types=1);
  * @license  https://github.com/hyperf-cloud/hyperf/blob/master/LICENSE
  */
 
-use Hyperf\Contract\ApplicationInterface;
-use Swoole\Runtime;
-
 ini_set('display_errors', 'on');
 ini_set('display_startup_errors', 'on');
 
 error_reporting(E_ALL);
 date_default_timezone_set('Asia/Shanghai');
 
-!defined('BASE_PATH') && define('BASE_PATH', dirname(__DIR__, 1));
+! defined('BASE_PATH') && define('BASE_PATH', dirname(__DIR__, 1));
 
-require BASE_PATH.'/vendor/autoload.php';
+Swoole\Runtime::enableCoroutine(true);
 
-$container = require BASE_PATH.'/config/container.php';
+require BASE_PATH . '/vendor/autoload.php';
 
-$container->get(ApplicationInterface::class);
+$container = require BASE_PATH . '/config/container.php';
+
+$container->get(Hyperf\Contract\ApplicationInterface::class);


### PR DESCRIPTION
单元测试时$this->clinet->get('/')会报错:InvalidArgumentException : Path Generator is not exists.
因为没有把 Hyperf\JsonRpc\Listener\RegisterProtocolListener 这个注册